### PR TITLE
fix test harness validation and ci rpc env mismatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Run Forge tests
         env:
           ETHERSCAN_API_KEY: ${{secrets.ETHERSCAN_API_KEY}}
-          MAINNET_RPC_URL: ${{secrets.MAINNET_RPC_URL}}
+          ETH_RPC_URL: ${{secrets.MAINNET_RPC_URL}}
+          BASE_RPC_URL: ${{secrets.BASE_RPC_URL}}
+          AVALANCHE_RPC_URL: ${{secrets.AVALANCHE_RPC_URL}}
           PLUME_RPC_URL: ${{secrets.PLUME_RPC_URL}}
         run: |
           forge test -vvv

--- a/src/test-harness/SpellRunner.sol
+++ b/src/test-harness/SpellRunner.sol
@@ -58,6 +58,7 @@ abstract contract SpellRunner is Test {
 
     mapping(ChainId => DomainData)   internal chainData;
     mapping(ChainId => LZOftPair[])  internal lzOftPairs;
+    mapping(ChainId => uint256)      internal foreignActionsSetCountBefore;
 
     ChainId[] internal allChains;
     string internal    id;
@@ -112,7 +113,22 @@ abstract contract SpellRunner is Test {
 
             string memory response = string(vm.ffi(curlCmd));
             // Result: {"status":"1","message":"OK","result":"18518418"}
+            string memory status = vm.parseJsonString(response, ".status");
+            require(
+                keccak256(bytes(status)) == keccak256(bytes("1")),
+                string(abi.encodePacked(
+                    "SpellRunner/etherscan-failed chainId=",
+                    chainId,
+                    " response=",
+                    response
+                ))
+            );
+
             blocks[i] = vm.parseJsonUint(response, ".result");
+            require(
+                blocks[i] > 0,
+                string(abi.encodePacked("SpellRunner/invalid-block chainId=", chainId))
+            );
         }
     }
 
@@ -293,12 +309,25 @@ abstract contract SpellRunner is Test {
 
     /// @dev takes care to revert the selected fork to what was chosen before
     function executeAllPayloadsAndBridges() internal {
+        _snapshotForeignActionsSetCounts();
         // only execute mainnet payload
         executeMainnetPayload();
         // then use bridges to execute other chains' payloads
         _relayMessageOverBridges(allChains);
         // execute the foreign payloads (either by simulation or real execute)
         _executeForeignPayloads();
+    }
+
+    function _snapshotForeignActionsSetCounts() private {
+        for (uint256 i = 0; i < allChains.length; i++) {
+            ChainId chainId = ChainIdUtils.fromDomain(chainData[allChains[i]].domain);
+            if (chainId == ChainIdUtils.Ethereum()) continue;
+
+            chainData[chainId].domain.selectFork();
+            foreignActionsSetCountBefore[chainId] = chainData[chainId].executor.actionsSetCount();
+        }
+
+        chainData[ChainIdUtils.Ethereum()].domain.selectFork();
     }
 
     /// @dev bridge contracts themselves are stored on mainnet
@@ -343,9 +372,18 @@ abstract contract SpellRunner is Test {
             address mainnetSpellPayload = _getForeignPayloadFromMainnetSpell(chainId);
             IExecutor executor = chainData[chainId].executor;
             if (mainnetSpellPayload != address(0)) {
-                // We assume the payload has been queued in the executor (will revert otherwise)
                 chainData[chainId].domain.selectFork();
-                uint256 actionsSetId = executor.actionsSetCount() - 1;
+                uint256 prevCount = foreignActionsSetCountBefore[chainId];
+                uint256 currentCount = executor.actionsSetCount();
+                require(
+                    currentCount == prevCount + 1,
+                    string(abi.encodePacked(
+                        "SpellRunner/relay-did-not-queue network=",
+                        chainId.toDomainString()
+                    ))
+                );
+
+                uint256 actionsSetId = currentCount - 1;
                 uint256 prevTimestamp = block.timestamp;
                 vm.warp(executor.getActionsSetById(actionsSetId).executionTime);
                 executor.execute(actionsSetId);


### PR DESCRIPTION
hey grove team, its mooncitydev. was poking around the test harness and ci and found a couple things that looked worth fixing.

first, `getBlocksFromDateByChainIds` in SpellRunner was parsing the etherscan block number straight from `.result` without checking `.status`. if the api key is bad, you hit a rate limit, or the request fails for any reason, forge just forks from block 0 or some garbage value and tests keep running against the wrong chain state. nobody gets a clear error. now it checks status is `1` and that the block number is actually > 0 before forking.

second, `_executeForeignPayloads` was blindly doing `actionsSetCount() - 1` assuming the last queued set is always from the current spell. if relay fails silently or something else queued an action set, tests could execute the wrong payload and still pass. added a snapshot of the count before relay and require it went up by exactly 1 before executing.

third, ci was setting `MAINNET_RPC_URL` but foundry std chains and the readme both expect `ETH_RPC_URL`, plus base and avalanche rpc vars were missing entirely. mapped those in the workflow so fork setup matches what `setupBlocksFromDate` actually reads.

side note: main currently has no `src/proposals/` spell so `forge test` runs zero tests and ci still goes green. might be worth a guard once the next spell lands.

cheers