### PR TITLE
update the foundry.lock file to track the current submodules we're us…

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -9,15 +9,15 @@
     "rev": "ca0351644f9ba52c7d90a6183042617ff8b75579"
   },
   "lib/grove-alm-controller": {
-    "rev": "d2378c794cddda99b85d6f4d7387a5a5efd35486"
+    "rev": "2c6e3d4297d5f244894d05f3dbbe47bcada34712"
   },
   "lib/grove-gov-relay": {
     "rev": "f314e2480204f4ab897ba757886b7af45d61b746"
   },
   "lib/spark-address-registry": {
-    "rev": "7970fef921881720179967e5fa8b7305e59cf61e"
+    "rev": "d3247083428eb9f7ebe797fd47758463401d1c26"
   },
   "lib/xchain-helpers": {
-    "rev": "c93404800dbcaafec4af068b04ce7df6df7c95fa"
+    "rev": "53f6ced11ae4828e7bd55ba7a6a713c97f2b19c4"
   }
 }


### PR DESCRIPTION
Our foundry.lock file seems to have drifted a bit from our submodules.  bringing things back in alignment:

| Stale lock entry | Lock rev | Actual gitlink (submodule) | Drift introduced by |
|---|---|---|---|
| `lib/grove-alm-controller` | `d2378c79` | `2c6e3d4` (tag **v1.8.0**, audited) | 🧢 January 15, 2026 Spell (#31, commit `bc2d22b`) |
| `lib/xchain-helpers` | `c934048` | `53f6ced` (tag **v1.2.0**, audited) | 🌉 Add CCTP v2 to SpellRunner execution pipeline (#29, commit `1d963ab`) |
| `lib/spark-address-registry` | `7970fef9` | `d324708` | 🏔️ August 7, 2025 Spell (#8, commit `45cbd5b`) |

Each was a submodule bump committed without regenerating `foundry.lock` (raw git instead of forge tooling).
Compilation is unaffected — CI and local builds compile the git submodule checkouts (the audited revisions) —
but the stale lock spams `revision mismatch` warnings on every build and would mislead a `forge install`-style restore.

**Fix applied here:** `git submodule update --init --recursive && rm foundry.lock && forge install`
(regenerates the lock from the checked-out submodules — note: bare `forge update` must NOT be used, as it
advances dependencies to upstream latest). Only the three entries above change.