### PR TITLE
⛱️ August 13, 2026 Spell

### DIFF
--- a/src/proposals/20260813/GroveEthereum_20260813.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.sol
@@ -45,7 +45,7 @@ contract GroveEthereum_20260813 is GrovePayloadEthereum {
         //   Forum : TODO
         _enableUniswapV3Facet();
 
-        // [Ethereum] Item 2: one-time collect of accrued fees on the Grove Uniswap V3 position.
+        // [Ethereum] Item 2: one-time collect of accrued fees on the Grove Uniswap V3 ALM Controller position.
         //   Forum : TODO
         _collectUniswapV3PositionFees();
 
@@ -62,13 +62,14 @@ contract GroveEthereum_20260813 is GrovePayloadEthereum {
 
         controller.updateIntegrations(integrationIds);
 
-        // Mirrors the live ALM-side AUSD/USDC config (January 29, 2026 onboarding).
+        // Mirrors the live ALM-side AUSD/USDC config (archive/20260129/GroveEthereum_20260129.sol).
         controller.uniswapV3_setMaxSlippage(Ethereum.UNISWAP_V3_AUSD_USDC, 0.999e18);
         controller.uniswapV3_setMaxTickDelta(Ethereum.UNISWAP_V3_AUSD_USDC, 200);
         controller.uniswapV3_setTWAPSecondsAgo(Ethereum.UNISWAP_V3_AUSD_USDC, 600);
         controller.uniswapV3_setLiquidityLowerTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, -10);
         controller.uniswapV3_setLiquidityUpperTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, 10);
 
+        // Rate limits follow the facet ramp-up risk parameters, not the Jan 29 ALM-side values.
         IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
             key       : makeAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.UNISWAP_V3_AUSD_USDC),
             maxAmount : 5_000_000e18,  // BEFORE: 0

--- a/src/proposals/20260813/GroveEthereum_20260813.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.sol
@@ -45,7 +45,7 @@ contract GroveEthereum_20260813 is GrovePayloadEthereum {
         //   Forum : https://forum.skyeco.com/t/august-13-2026-proposed-changes-to-grove-for-upcoming-spell/28126#p-106981-proposed-actions-13
         _enableUniswapV3Facet();
 
-        // [Ethereum] Item 2: one-time collect of accrued fees on the Grove Uniswap V3 ALM Controller position.
+        // [Ethereum] Item 2: one-time collect of accrued fees on the Grove Uniswap V3 ALM Proxy position.
         //   Forum : https://forum.skyeco.com/t/august-13-2026-proposed-changes-to-grove-for-upcoming-spell/28126#p-106981-proposed-actions-13
         _collectUniswapV3PositionFees();
 
@@ -63,13 +63,17 @@ contract GroveEthereum_20260813 is GrovePayloadEthereum {
         controller.updateIntegrations(integrationIds);
 
         // Mirrors the live ALM-side AUSD/USDC config (archive/20260129/GroveEthereum_20260129.sol).
-        controller.uniswapV3_setMaxSlippage(Ethereum.UNISWAP_V3_AUSD_USDC, 0.999e18);
-        controller.uniswapV3_setMaxTickDelta(Ethereum.UNISWAP_V3_AUSD_USDC, 200);
-        controller.uniswapV3_setTWAPSecondsAgo(Ethereum.UNISWAP_V3_AUSD_USDC, 600);
-        controller.uniswapV3_setLiquidityLowerTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, -10);
-        controller.uniswapV3_setLiquidityUpperTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, 10);
+        // maxSlippage bounds addLiquidity/removeLiquidity only.
+        // swap() is bounded by maxTickDelta, against the TWAP and by the relayer's own minAmountOut.
+        controller.uniswapV3_setMaxSlippage(Ethereum.UNISWAP_V3_AUSD_USDC, 0.999e18);         // BEFORE: 0
+        controller.uniswapV3_setMaxTickDelta(Ethereum.UNISWAP_V3_AUSD_USDC, 200);             // BEFORE: 0
+        controller.uniswapV3_setTWAPSecondsAgo(Ethereum.UNISWAP_V3_AUSD_USDC, 600);           // BEFORE: 0
+        controller.uniswapV3_setLiquidityLowerTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, -10);  // BEFORE: 0
+        controller.uniswapV3_setLiquidityUpperTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, 10);   // BEFORE: 0
 
         // Rate limits follow the facet ramp-up risk parameters, not the Jan 29 ALM-side values.
+        // The aggregate key meters the 1e18-normalised sum across both pool tokens, so it is set in e18;
+        // the per-asset and swap keys meter raw token amounts and both tokens are 6-decimal.
         IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
             key       : makeAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.UNISWAP_V3_AUSD_USDC),
             maxAmount : 5_000_000e18,  // BEFORE: 0
@@ -86,6 +90,7 @@ contract GroveEthereum_20260813 is GrovePayloadEthereum {
             slope     : 0             // BEFORE: 0
         });
 
+        // Withdrawals set unlimited - BEFORE: 0 max ; 0 slope (unset; RateLimits reverts on an unset key).
         IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setUnlimitedRateLimitData(
             makeAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.UNISWAP_V3_AUSD_USDC)
         );

--- a/src/proposals/20260813/GroveEthereum_20260813.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.sol
@@ -62,17 +62,13 @@ contract GroveEthereum_20260813 is GrovePayloadEthereum {
 
         controller.updateIntegrations(integrationIds);
 
-        // Pool params mirror the live ALM-side AUSD/USDC config (January 29, 2026 onboarding);
-        // the facet requires them before addLiquidity or swap can succeed.
+        // Mirrors the live ALM-side AUSD/USDC config (January 29, 2026 onboarding).
         controller.uniswapV3_setMaxSlippage(Ethereum.UNISWAP_V3_AUSD_USDC, 0.999e18);
         controller.uniswapV3_setMaxTickDelta(Ethereum.UNISWAP_V3_AUSD_USDC, 200);
         controller.uniswapV3_setTWAPSecondsAgo(Ethereum.UNISWAP_V3_AUSD_USDC, 600);
         controller.uniswapV3_setLiquidityLowerTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, -10);
         controller.uniswapV3_setLiquidityUpperTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, 10);
 
-        // Zero slopes make the 5M deposit allowances cumulative for the ramp-up phase rather than
-        // daily. The facet meters the aggregate key in 1e18-normalized units (per-asset keys in
-        // raw token units), so the aggregate is 5_000_000e18 for a 5M token cap.
         IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
             key       : makeAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.UNISWAP_V3_AUSD_USDC),
             maxAmount : 5_000_000e18,  // BEFORE: 0
@@ -99,8 +95,6 @@ contract GroveEthereum_20260813 is GrovePayloadEthereum {
             makeAddressAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC)
         );
 
-        // Unlike the deposit keys, the swap allowances replenish: the maximum bounds any single
-        // burst at 1M, the slope governs throughput at 5M per day.
         IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
             key       : makeAddressAddressKey(LIMIT_UNISWAP_V3_SWAP, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC),
             maxAmount : 1_000_000e6,                   // BEFORE: 0

--- a/src/proposals/20260813/GroveEthereum_20260813.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.sol
@@ -42,15 +42,15 @@ contract GroveEthereum_20260813 is GrovePayloadEthereum {
 
     function _execute() internal override {
         // [Ethereum] Item 1: enable the UniswapV3 facet on the Grove DPAU controller and onboard the AUSD/USDC pool.
-        //   Forum : TODO
+        //   Forum : https://forum.skyeco.com/t/august-13-2026-proposed-changes-to-grove-for-upcoming-spell/28126#p-106981-proposed-actions-13
         _enableUniswapV3Facet();
 
         // [Ethereum] Item 2: one-time collect of accrued fees on the Grove Uniswap V3 ALM Controller position.
-        //   Forum : TODO
+        //   Forum : https://forum.skyeco.com/t/august-13-2026-proposed-changes-to-grove-for-upcoming-spell/28126#p-106981-proposed-actions-13
         _collectUniswapV3PositionFees();
 
         // [Ethereum] Item 3: offboard the Maple syrupUSDC deposit rate limit.
-        //   Forum : TODO
+        //   Forum : https://forum.skyeco.com/t/august-13-2026-proposed-changes-to-grove-for-upcoming-spell/28126#p-106981-proposed-actions-13
         _offboardMapleSyrupUsdcDepositRateLimit();
     }
 

--- a/src/proposals/20260813/GroveEthereum_20260813.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.34;
+
+import { Ethereum } from "lib/grove-address-registry/src/Ethereum.sol";
+
+import { MainnetController } from "lib/grove-alm-controller/src/MainnetController.sol";
+import { RateLimitHelpers }  from "lib/grove-alm-controller/src/RateLimitHelpers.sol";
+
+import { IALMProxy }   from "lib/grove-alm-controller/src/interfaces/IALMProxy.sol";
+import { IRateLimits } from "lib/grove-alm-controller/src/interfaces/IRateLimits.sol";
+
+import { INonfungiblePositionManager } from "lib/grove-alm-controller/src/interfaces/UniswapV3Interfaces.sol";
+
+import { IRateLimits as IPauRateLimits }         from "diamond-pau/interfaces/IRateLimits.sol";
+import { makeAddressKey, makeAddressAddressKey } from "diamond-pau/libraries/RateLimitHelpers.sol";
+
+import { GrovePayloadEthereum } from "src/libraries/payloads/GrovePayloadEthereum.sol";
+
+interface IPauControllerLike {
+    function updateIntegrations(bytes32[] calldata integrationIds) external;
+    function uniswapV3_setLiquidityLowerTickBound(address pool, int24 lowerTickBound) external;
+    function uniswapV3_setLiquidityUpperTickBound(address pool, int24 upperTickBound) external;
+    function uniswapV3_setMaxSlippage(address pool, uint256 maxSlippage) external;
+    function uniswapV3_setMaxTickDelta(address pool, uint24 maxTickDelta) external;
+    function uniswapV3_setTWAPSecondsAgo(address pool, uint32 twapSecondsAgo) external;
+}
+
+/**
+ * @title  August 13, 2026 Grove Ethereum Proposal
+ * @author Grove Labs
+ */
+contract GroveEthereum_20260813 is GrovePayloadEthereum {
+
+    bytes32 internal constant UNISWAP_V3_FACET_ID = bytes32("UNISWAP_V3_FACET");
+
+    bytes32 internal constant LIMIT_UNISWAP_V3_DEPOSIT  = keccak256("LIMIT_UNISWAP_V3_DEPOSIT");
+    bytes32 internal constant LIMIT_UNISWAP_V3_SWAP     = keccak256("LIMIT_UNISWAP_V3_SWAP");
+    bytes32 internal constant LIMIT_UNISWAP_V3_WITHDRAW = keccak256("LIMIT_UNISWAP_V3_WITHDRAW");
+
+    // Grove AUSD/USDC position NFT held by the ALM Proxy.
+    uint256 internal constant UNISWAP_V3_POSITION_TOKEN_ID = 1192575;
+
+    function _execute() internal override {
+        // [Ethereum] Item 1: enable the UniswapV3 facet on the Grove DPAU controller and onboard the AUSD/USDC pool.
+        //   Forum : TODO
+        _enableUniswapV3Facet();
+
+        // [Ethereum] Item 2: one-time collect of accrued fees on the Grove Uniswap V3 position.
+        //   Forum : TODO
+        _collectUniswapV3PositionFees();
+
+        // [Ethereum] Item 3: offboard the Maple syrupUSDC deposit rate limit.
+        //   Forum : TODO
+        _offboardMapleSyrupUsdcDepositRateLimit();
+    }
+
+    function _enableUniswapV3Facet() internal {
+        IPauControllerLike controller = IPauControllerLike(Ethereum.PAU_CONTROLLER);
+
+        bytes32[] memory integrationIds = new bytes32[](1);
+        integrationIds[0] = UNISWAP_V3_FACET_ID;
+
+        controller.updateIntegrations(integrationIds);
+
+        // Pool params mirror the live ALM-side AUSD/USDC config (January 29, 2026 onboarding);
+        // the facet requires them before addLiquidity or swap can succeed.
+        controller.uniswapV3_setMaxSlippage(Ethereum.UNISWAP_V3_AUSD_USDC, 0.999e18);
+        controller.uniswapV3_setMaxTickDelta(Ethereum.UNISWAP_V3_AUSD_USDC, 200);
+        controller.uniswapV3_setTWAPSecondsAgo(Ethereum.UNISWAP_V3_AUSD_USDC, 600);
+        controller.uniswapV3_setLiquidityLowerTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, -10);
+        controller.uniswapV3_setLiquidityUpperTickBound(Ethereum.UNISWAP_V3_AUSD_USDC, 10);
+
+        // Zero slopes make the 5M deposit allowances cumulative for the ramp-up phase rather than
+        // daily. The facet meters the aggregate key in 1e18-normalized units (per-asset keys in
+        // raw token units), so the aggregate is 5_000_000e18 for a 5M token cap.
+        IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
+            key       : makeAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.UNISWAP_V3_AUSD_USDC),
+            maxAmount : 5_000_000e18,  // BEFORE: 0
+            slope     : 0              // BEFORE: 0
+        });
+        IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
+            key       : makeAddressAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC),
+            maxAmount : 5_000_000e6,  // BEFORE: 0
+            slope     : 0             // BEFORE: 0
+        });
+        IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
+            key       : makeAddressAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC),
+            maxAmount : 5_000_000e6,  // BEFORE: 0
+            slope     : 0             // BEFORE: 0
+        });
+
+        IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setUnlimitedRateLimitData(
+            makeAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.UNISWAP_V3_AUSD_USDC)
+        );
+        IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setUnlimitedRateLimitData(
+            makeAddressAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC)
+        );
+        IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setUnlimitedRateLimitData(
+            makeAddressAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC)
+        );
+
+        // Unlike the deposit keys, the swap allowances replenish: the maximum bounds any single
+        // burst at 1M, the slope governs throughput at 5M per day.
+        IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
+            key       : makeAddressAddressKey(LIMIT_UNISWAP_V3_SWAP, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC),
+            maxAmount : 1_000_000e6,                   // BEFORE: 0
+            slope     : 5_000_000e6 / uint256(1 days)  // BEFORE: 0
+        });
+        IPauRateLimits(Ethereum.PAU_RATE_LIMITS).setRateLimitData({
+            key       : makeAddressAddressKey(LIMIT_UNISWAP_V3_SWAP, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC),
+            maxAmount : 1_000_000e6,                   // BEFORE: 0
+            slope     : 5_000_000e6 / uint256(1 days)  // BEFORE: 0
+        });
+    }
+
+    function _collectUniswapV3PositionFees() internal {
+        IALMProxy almProxy = IALMProxy(Ethereum.ALM_PROXY);
+
+        almProxy.grantRole(almProxy.CONTROLLER(), Ethereum.GROVE_PROXY);
+
+        almProxy.doCall(
+            Ethereum.UNISWAP_V3_POSITION_MANAGER,
+            abi.encodeCall(
+                INonfungiblePositionManager.collect,
+                INonfungiblePositionManager.CollectParams({
+                    tokenId    : UNISWAP_V3_POSITION_TOKEN_ID,
+                    recipient  : Ethereum.ALM_PROXY,
+                    amount0Max : type(uint128).max,
+                    amount1Max : type(uint128).max
+                })
+            )
+        );
+
+        almProxy.revokeRole(almProxy.CONTROLLER(), Ethereum.GROVE_PROXY);
+    }
+
+    function _offboardMapleSyrupUsdcDepositRateLimit() internal {
+        bytes32 depositKey = RateLimitHelpers.makeAssetKey(
+            MainnetController(Ethereum.ALM_CONTROLLER).LIMIT_4626_DEPOSIT(),
+            Ethereum.MAPLE_SYRUP_USDC
+        );
+
+        IRateLimits(Ethereum.ALM_RATE_LIMITS).setRateLimitData({
+            key       : depositKey,
+            maxAmount : 0,  // BEFORE: 50_000_000e6
+            slope     : 0   // BEFORE: 50_000_000e6 / 1 days
+        });
+    }
+
+}

--- a/src/proposals/20260813/GroveEthereum_20260813.t.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.t.sol
@@ -102,6 +102,8 @@ interface IPauControllerLike is IPauBaseControllerLike {
 
 contract GroveEthereum_20260813_Test is GroveTestBase {
 
+    address internal constant PAYLOAD_ETHEREUM = 0xb12C687188427d7D1E5253afA5f09A101Fbd9d4b;
+
     // UNISWAP_V3_FACET in the Sky-governed PAU Beacon.
     address internal constant PAU_UNISWAP_V3_FACET = 0x445D9Dc752F269Be48250f1A180CAC4c61cE4bab;
 
@@ -124,9 +126,9 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
     }
 
     function setUp() public {
-        setupDomains("2026-07-29T10:13:44Z");
+        setupDomains("2026-08-07T10:00:00Z");
 
-        deployPayloads();
+        chainData[ChainIdUtils.Ethereum()].payload = PAYLOAD_ETHEREUM;
     }
 
     function test_ETHEREUM_enableUniswapV3Facet() public onChain(ChainIdUtils.Ethereum()) {
@@ -424,8 +426,8 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         executeAllPayloadsAndBridges();
 
         // Fees owed on the position, pinned to the deterministic mainnet fork block (both 6 decimals).
-        assertEq(ausd.balanceOf(Ethereum.ALM_PROXY) - ausdBalance, 29_362.725254e6, "ausd-fees-collected-mismatch");
-        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY) - usdcBalance, 28_113.645384e6, "usdc-fees-collected-mismatch");
+        assertEq(ausd.balanceOf(Ethereum.ALM_PROXY) - ausdBalance, 29_992.197726e6, "ausd-fees-collected-mismatch");
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY) - usdcBalance, 28_871.017982e6, "usdc-fees-collected-mismatch");
 
         // Only owed fees move: the position keeps its liquidity, its range and its owner.
         IPositionManagerLike.Position memory positionAfter = positionManager.positions(UNISWAP_V3_POSITION_TOKEN_ID);

--- a/src/proposals/20260813/GroveEthereum_20260813.t.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.t.sol
@@ -20,8 +20,7 @@ import { GroveLiquidityLayerContext } from "src/test-harness/CommonALMTestBase.s
 
 import { IPauBaseControllerLike, PauContext } from "src/test-harness/CommonPauTestBase.sol";
 
-// `positions` returns a struct (ABI-identical to the manager's 12-value tuple) because decoding
-// the tuple into locals overflows the stack without viaIR.
+// Struct return, ABI-identical to the manager's 12-value tuple: decoding into locals overflows the stack without viaIR.
 interface IPositionManagerLike {
     struct Position {
         uint96  nonce;
@@ -108,8 +107,6 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
     bytes32 internal constant LIMIT_UNISWAP_V3_SWAP     = keccak256("LIMIT_UNISWAP_V3_SWAP");
     bytes32 internal constant LIMIT_UNISWAP_V3_WITHDRAW = keccak256("LIMIT_UNISWAP_V3_WITHDRAW");
 
-    // The aggregate key is metered by the facet in 1e18-normalized units, per-asset keys in raw
-    // token units. Zero deposit slopes make the allowances cumulative for the ramp-up phase.
     uint256 internal constant AGGREGATE_DEPOSIT_MAX   = 5_000_000e18;
     uint256 internal constant AGGREGATE_DEPOSIT_SLOPE = 0;
     uint256 internal constant ASSET_DEPOSIT_MAX       = 5_000_000e6;
@@ -244,8 +241,7 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         bytes32 ausdDepositKey      = makeAddressAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
         bytes32 usdcDepositKey      = makeAddressAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
 
-        // A single-sided USDC range strictly below the TWAP tick keeps the facet's expected
-        // amounts price-independent, so exact min amounts can be computed here.
+        // A single-sided USDC range strictly below the TWAP tick makes the expected amounts price-independent.
         int24 tickUpper = _twapTick(Ethereum.UNISWAP_V3_AUSD_USDC, 600) - 1;
         if (tickUpper > 10) tickUpper = 10;
         assertGt(tickUpper, -10, "twap-tick-outside-liquidity-bounds");
@@ -272,7 +268,6 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
 
         assertEq(IPositionManagerLike(Ethereum.UNISWAP_V3_POSITION_MANAGER).ownerOf(tokenId), address(ctx.proxy), "position-not-owned-by-pau-proxy");
 
-        // Deposits consume the limits: the aggregate in 1e18-normalized units, per-asset raw.
         assertEq(ctx.rateLimits.getCurrentRateLimit(aggregateDepositKey), AGGREGATE_DEPOSIT_MAX - deposited.amount1 * 1e12, "aggregate-deposit-limit-not-consumed");
         assertEq(ctx.rateLimits.getCurrentRateLimit(usdcDepositKey),      ASSET_DEPOSIT_MAX - deposited.amount1,            "usdc-deposit-limit-not-consumed");
         assertEq(ctx.rateLimits.getCurrentRateLimit(ausdDepositKey),      ASSET_DEPOSIT_MAX,                                "ausd-deposit-limit-consumed");
@@ -318,8 +313,7 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
 
         uint256 proxyAusdBalance = IERC20(Ethereum.AUSD).balanceOf(address(ctx.proxy));
 
-        // 0.2% tolerance covers the pool's 0.01% fee plus a near-peg price; tick delta at the
-        // configured swapMaxTickDelta.
+        // 0.2% tolerance covers the pool's 0.01% fee plus a near-peg price; tick delta at the configured max.
         bytes memory result = _callAsPauActor(ctx, abi.encodeCall(
             IPauControllerLike.uniswapV3_swap,
             (Ethereum.UNISWAP_V3_AUSD_USDC, Ethereum.USDC, amountIn, amountIn * 998 / 1000, 200)
@@ -332,7 +326,6 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         assertEq(IERC20(Ethereum.AUSD).balanceOf(address(ctx.proxy)), proxyAusdBalance + amountOut, "proxy-ausd-balance-mismatch");
         assertEq(IERC20(Ethereum.USDC).balanceOf(address(ctx.proxy)), 0,                            "usdc-not-fully-spent");
 
-        // The swap consumes the tokenIn key by the amount spent; the AUSD key stays untouched.
         assertEq(ctx.rateLimits.getCurrentRateLimit(usdcSwapKey), SWAP_MAX - amountIn, "usdc-swap-limit-not-consumed");
         assertEq(ctx.rateLimits.getCurrentRateLimit(ausdSwapKey), SWAP_MAX,            "ausd-swap-limit-consumed");
     }
@@ -362,8 +355,7 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         uint256 ausdBalance = ausd.balanceOf(Ethereum.ALM_PROXY);
         uint256 usdcBalance = usdc.balanceOf(Ethereum.ALM_PROXY);
 
-        // The spec pins no amounts (Post-checks §2: "whatever has accrued at execution"),
-        // so the balance assertions below are bounds rather than exact values.
+        // The spec pins no amounts, so the balance assertions are bounds rather than exact values.
         executeAllPayloadsAndBridges();
 
         assertGe(ausd.balanceOf(Ethereum.ALM_PROXY), ausdBalance, "alm-proxy-ausd-balance-decreased");
@@ -375,7 +367,7 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
             "no-fees-collected"
         );
 
-        // Only owed fees move: the position keeps its liquidity and stays with the ALM Proxy.
+        // Only owed fees move: the position keeps its liquidity and its owner.
         IPositionManagerLike.Position memory positionAfter = positionManager.positions(UNISWAP_V3_POSITION_TOKEN_ID);
 
         assertEq(positionAfter.liquidity,   position.liquidity, "position-liquidity-changed");
@@ -418,7 +410,7 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         bytes32 depositKey  = RateLimitHelpers.makeAssetKey(MainnetController(ctx.controller).LIMIT_4626_DEPOSIT(),  Ethereum.MAPLE_SYRUP_USDC);
         bytes32 withdrawKey = RateLimitHelpers.makeAssetKey(MainnetController(ctx.controller).LIMIT_4626_WITHDRAW(), Ethereum.MAPLE_SYRUP_USDC);
 
-        // Key published in the spec (Post-checks §3), recomputed here from the live controller.
+        // Key published in the spec, recomputed here from the live controller.
         assertEq(depositKey, 0x99a69e57b2f387f999d6adff6eb2e707b59fdb54f06ca6211b4f20956e9bfe10, "syrup-usdc-deposit-key-mismatch");
 
         // --- Before: deposits still capped at the onboarded 50M limit, withdrawals never set. ---

--- a/src/proposals/20260813/GroveEthereum_20260813.t.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.t.sol
@@ -355,17 +355,11 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         uint256 ausdBalance = ausd.balanceOf(Ethereum.ALM_PROXY);
         uint256 usdcBalance = usdc.balanceOf(Ethereum.ALM_PROXY);
 
-        // The spec pins no amounts, so the balance assertions are bounds rather than exact values.
         executeAllPayloadsAndBridges();
 
-        assertGe(ausd.balanceOf(Ethereum.ALM_PROXY), ausdBalance, "alm-proxy-ausd-balance-decreased");
-        assertGe(usdc.balanceOf(Ethereum.ALM_PROXY), usdcBalance, "alm-proxy-usdc-balance-decreased");
-
-        assertGt(
-            ausd.balanceOf(Ethereum.ALM_PROXY) + usdc.balanceOf(Ethereum.ALM_PROXY),
-            ausdBalance + usdcBalance,
-            "no-fees-collected"
-        );
+        // Fees owed on the position, pinned to the deterministic mainnet fork block (both 6 decimals).
+        assertEq(ausd.balanceOf(Ethereum.ALM_PROXY) - ausdBalance, 29_362.725254e6, "ausd-fees-collected-mismatch");
+        assertEq(usdc.balanceOf(Ethereum.ALM_PROXY) - usdcBalance, 28_113.645384e6, "usdc-fees-collected-mismatch");
 
         // Only owed fees move: the position keeps its liquidity and its owner.
         IPositionManagerLike.Position memory positionAfter = positionManager.positions(UNISWAP_V3_POSITION_TOKEN_ID);

--- a/src/proposals/20260813/GroveEthereum_20260813.t.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.t.sol
@@ -429,7 +429,14 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
 
         ( int56[] memory tickCumulatives, ) = IUniswapV3PoolLike(pool).observe(secondsAgos);
 
-        return int24((tickCumulatives[1] - tickCumulatives[0]) / int56(uint56(secondsAgo)));
+        int56 tickCumulativesDelta = tickCumulatives[1] - tickCumulatives[0];
+
+        int24 arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsAgo)));
+
+        // Mirrors UniswapV3Utils: always round to negative infinity.
+        if (tickCumulativesDelta < 0 && tickCumulativesDelta % int56(uint56(secondsAgo)) != 0) arithmeticMeanTick--;
+
+        return arithmeticMeanTick;
     }
 
 }

--- a/src/proposals/20260813/GroveEthereum_20260813.t.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.t.sol
@@ -20,6 +20,8 @@ import { GroveLiquidityLayerContext } from "src/test-harness/CommonALMTestBase.s
 
 import { IPauBaseControllerLike, PauContext } from "src/test-harness/CommonPauTestBase.sol";
 
+import { IStarGuardLike } from "src/test-harness/SpellRunner.sol";
+
 // Struct return, ABI-identical to the manager's 12-value tuple: decoding into locals overflows the stack without viaIR.
 interface IPositionManagerLike {
     struct Position {
@@ -228,7 +230,7 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         assertEq(upperTickBound, 10,  "upper-tick-bound-mismatch");
     }
 
-    function test_ETHEREUM_uniswapV3FacetAddRemoveLiquidity() public onChain(ChainIdUtils.Ethereum()) {
+    function test_ETHEREUM_uniswapV3FacetAddRemoveLiquidityUsdc() public onChain(ChainIdUtils.Ethereum()) {
         executeAllPayloadsAndBridges();
 
         PauContext memory ctx = _getPauContext();
@@ -299,6 +301,65 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         );
     }
 
+    function test_ETHEREUM_uniswapV3FacetAddRemoveLiquidityAusd() public onChain(ChainIdUtils.Ethereum()) {
+        executeAllPayloadsAndBridges();
+
+        PauContext memory ctx = _getPauContext();
+
+        uint256 depositAmount = 1_000_000e6;
+
+        deal2(Ethereum.AUSD, address(ctx.proxy), depositAmount);
+
+        bytes32 ausdWithdrawKey = makeAddressAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 usdcWithdrawKey = makeAddressAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
+
+        // Mirror of the USDC case: a single-sided AUSD range strictly above the TWAP tick.
+        int24 tickLower = _twapTick(Ethereum.UNISWAP_V3_AUSD_USDC, 600) + 1;
+        if (tickLower < -10) tickLower = -10;
+        assertLt(tickLower, 10, "twap-tick-outside-liquidity-bounds");
+
+        bytes memory result = _callAsPauActor(ctx, abi.encodeCall(
+            IPauControllerLike.uniswapV3_addLiquidity,
+            (
+                Ethereum.UNISWAP_V3_AUSD_USDC,
+                0,
+                IPauControllerLike.Ticks({ lower: tickLower, upper: 10 }),
+                IPauControllerLike.TokenAmounts({ amount0: depositAmount, amount1: 0 }),
+                IPauControllerLike.TokenAmounts({ amount0: depositAmount * 999 / 1000, amount1: 0 }),
+                block.timestamp + 1 hours
+            )
+        ));
+
+        ( uint256 tokenId, uint128 liquidity, IPauControllerLike.TokenAmounts memory deposited ) =
+            abi.decode(result, (uint256, uint128, IPauControllerLike.TokenAmounts));
+
+        assertEq(deposited.amount1, 0,                          "usdc-unexpectedly-deposited");
+        assertGe(deposited.amount0, depositAmount * 999 / 1000, "ausd-deposited-below-min");
+
+        uint256 proxyAusdBalance = IERC20(Ethereum.AUSD).balanceOf(address(ctx.proxy));
+
+        result = _callAsPauActor(ctx, abi.encodeCall(
+            IPauControllerLike.uniswapV3_removeLiquidity,
+            (
+                Ethereum.UNISWAP_V3_AUSD_USDC,
+                tokenId,
+                liquidity,
+                IPauControllerLike.TokenAmounts({ amount0: deposited.amount0 * 999 / 1000, amount1: 0 }),
+                block.timestamp + 1 hours
+            )
+        ));
+
+        IPauControllerLike.TokenAmounts memory withdrawn = abi.decode(result, (IPauControllerLike.TokenAmounts));
+
+        assertGe(withdrawn.amount0, deposited.amount0 * 999 / 1000, "ausd-not-returned");
+
+        assertEq(IERC20(Ethereum.AUSD).balanceOf(address(ctx.proxy)), proxyAusdBalance + withdrawn.amount0, "proxy-ausd-balance-mismatch");
+
+        // An unset withdraw key reverts the removal, so a successful AUSD-side unwind is the end-to-end proof.
+        assertEq(ctx.rateLimits.getCurrentRateLimit(ausdWithdrawKey), type(uint256).max, "ausd-withdraw-limit-not-unlimited");
+        assertEq(ctx.rateLimits.getCurrentRateLimit(usdcWithdrawKey), type(uint256).max, "usdc-withdraw-limit-not-unlimited");
+    }
+
     function test_ETHEREUM_uniswapV3FacetSwap() public onChain(ChainIdUtils.Ethereum()) {
         executeAllPayloadsAndBridges();
 
@@ -343,6 +404,11 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
 
         assertEq(position.token0, Ethereum.AUSD, "position-token0-not-ausd");
         assertEq(position.token1, Ethereum.USDC, "position-token1-not-usdc");
+        assertEq(position.fee,    100,           "position-fee-tier-mismatch");
+
+        // The position's own range, a different object from the [-10, 10] tick bounds Item 1 configures on the facet.
+        assertEq(position.tickLower, -1, "position-tick-lower-mismatch");
+        assertEq(position.tickUpper,  1, "position-tick-upper-mismatch");
 
         // The tokenId in the payload is the ALM Proxy's one and only position NFT.
         assertEq(positionManager.balanceOf(Ethereum.ALM_PROXY),               1,                             "alm-proxy-position-count-not-one");
@@ -361,16 +427,44 @@ contract GroveEthereum_20260813_Test is GroveTestBase {
         assertEq(ausd.balanceOf(Ethereum.ALM_PROXY) - ausdBalance, 29_362.725254e6, "ausd-fees-collected-mismatch");
         assertEq(usdc.balanceOf(Ethereum.ALM_PROXY) - usdcBalance, 28_113.645384e6, "usdc-fees-collected-mismatch");
 
-        // Only owed fees move: the position keeps its liquidity and its owner.
+        // Only owed fees move: the position keeps its liquidity, its range and its owner.
         IPositionManagerLike.Position memory positionAfter = positionManager.positions(UNISWAP_V3_POSITION_TOKEN_ID);
 
         assertEq(positionAfter.liquidity,   position.liquidity, "position-liquidity-changed");
+        assertEq(positionAfter.tickLower,   position.tickLower, "position-tick-lower-changed");
+        assertEq(positionAfter.tickUpper,   position.tickUpper, "position-tick-upper-changed");
         assertEq(positionAfter.tokensOwed0, 0,                  "token0-fees-not-fully-collected");
         assertEq(positionAfter.tokensOwed1, 0,                  "token1-fees-not-fully-collected");
 
         assertEq(positionManager.ownerOf(UNISWAP_V3_POSITION_TOKEN_ID), Ethereum.ALM_PROXY, "position-owner-changed");
 
         assertEq(almProxy.hasRole(controllerRole, Ethereum.GROVE_PROXY), false);
+    }
+
+    function test_ETHEREUM_collectRevertLeavesNoControllerRole() public onChain(ChainIdUtils.Ethereum()) {
+        IALMProxy almProxy = IALMProxy(Ethereum.ALM_PROXY);
+
+        bytes32 controllerRole = almProxy.CONTROLLER();
+
+        assertEq(almProxy.hasRole(controllerRole, Ethereum.GROVE_PROXY), false, "controller-role-granted-before");
+
+        // Fail the only call the payload makes inside the grant/revoke window.
+        vm.mockCallRevert(
+            Ethereum.UNISWAP_V3_POSITION_MANAGER,
+            abi.encodeWithSignature("collect((uint256,address,uint128,uint128))"),
+            abi.encodeWithSignature("Error(string)", "collect-forced-revert")
+        );
+
+        address payload = chainData[ChainIdUtils.Ethereum()].payload;
+
+        vm.prank(Ethereum.PAUSE_PROXY);
+        IStarGuardLike(Ethereum.GROVE_STAR_GUARD).plot(payload, keccak256(payload.code));
+
+        // The SubProxy masks the inner reason, so the forced failure surfaces as its own delegatecall error.
+        vm.expectRevert("SubProxy/delegatecall-error");
+        IStarGuardLike(Ethereum.GROVE_STAR_GUARD).exec();
+
+        assertEq(almProxy.hasRole(controllerRole, Ethereum.GROVE_PROXY), false, "controller-role-left-granted");
     }
 
     function test_ETHEREUM_almUniswapV3RateLimitsUnchanged() public onChain(ChainIdUtils.Ethereum()) {

--- a/src/proposals/20260813/GroveEthereum_20260813.t.sol
+++ b/src/proposals/20260813/GroveEthereum_20260813.t.sol
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.34;
+
+import { IERC20 } from "forge-std/interfaces/IERC20.sol";
+
+import { Ethereum } from "lib/grove-address-registry/src/Ethereum.sol";
+
+import { MainnetController } from "lib/grove-alm-controller/src/MainnetController.sol";
+import { RateLimitHelpers }  from "lib/grove-alm-controller/src/RateLimitHelpers.sol";
+
+import { IALMProxy } from "lib/grove-alm-controller/src/interfaces/IALMProxy.sol";
+
+import { makeAddressKey, makeAddressAddressKey } from "diamond-pau/libraries/RateLimitHelpers.sol";
+
+import { ChainIdUtils } from "src/libraries/helpers/ChainId.sol";
+
+import { GroveTestBase } from "src/test-harness/GroveTestBase.sol";
+
+import { GroveLiquidityLayerContext } from "src/test-harness/CommonALMTestBase.sol";
+
+import { IPauBaseControllerLike, PauContext } from "src/test-harness/CommonPauTestBase.sol";
+
+// `positions` returns a struct (ABI-identical to the manager's 12-value tuple) because decoding
+// the tuple into locals overflows the stack without viaIR.
+interface IPositionManagerLike {
+    struct Position {
+        uint96  nonce;
+        address operator;
+        address token0;
+        address token1;
+        uint24  fee;
+        int24   tickLower;
+        int24   tickUpper;
+        uint128 liquidity;
+        uint256 feeGrowthInside0LastX128;
+        uint256 feeGrowthInside1LastX128;
+        uint128 tokensOwed0;
+        uint128 tokensOwed1;
+    }
+
+    function balanceOf(address owner) external view returns (uint256 balance);
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+    function positions(uint256 tokenId) external view returns (Position memory position);
+    function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256 tokenId);
+}
+
+interface IUniswapV3PoolLike {
+    function observe(uint32[] calldata secondsAgos)
+        external view returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s);
+}
+
+interface IPauControllerLike is IPauBaseControllerLike {
+    struct Ticks {
+        int24 lower;
+        int24 upper;
+    }
+
+    struct TokenAmounts {
+        uint256 amount0;
+        uint256 amount1;
+    }
+
+    function uniswapV3_VERSION() external pure returns (string memory);
+    function uniswapV3_MAX_TICK_DELTA() external pure returns (uint24);
+    function uniswapV3_MIN_TICK() external pure returns (int24);
+    function uniswapV3_MAX_TICK() external pure returns (int24);
+    function uniswapV3_positionManager() external view returns (address);
+    function uniswapV3_router() external view returns (address);
+    function uniswapV3_setLiquidityLowerTickBound(address pool, int24 lowerTickBound) external;
+    function uniswapV3_setLiquidityUpperTickBound(address pool, int24 upperTickBound) external;
+    function uniswapV3_setMaxSlippage(address pool, uint256 maxSlippage) external;
+    function uniswapV3_setMaxTickDelta(address pool, uint24 maxTickDelta) external;
+    function uniswapV3_setTWAPSecondsAgo(address pool, uint32 twapSecondsAgo) external;
+    function uniswapV3_swap(address pool, address tokenIn, uint256 amountIn, uint256 minAmountOut, uint24 tickDelta)
+        external returns (uint256 amountOut);
+    function uniswapV3_getAggregateDepositRateLimitKey(address pool) external view returns (bytes32);
+    function uniswapV3_getAggregateWithdrawRateLimitKey(address pool) external view returns (bytes32);
+    function uniswapV3_getAssetDepositRateLimitKey(address pool, address token) external view returns (bytes32);
+    function uniswapV3_getAssetWithdrawRateLimitKey(address pool, address token) external view returns (bytes32);
+    function uniswapV3_getSwapRateLimitKey(address pool, address token) external view returns (bytes32);
+    function uniswapV3_getLiquidityTickBounds(address pool) external view returns (int24 lower, int24 upper);
+    function uniswapV3_getMaxSlippage(address pool) external view returns (uint256);
+    function uniswapV3_getMaxTickDelta(address pool) external view returns (uint24);
+    function uniswapV3_getTWAPSecondsAgo(address pool) external view returns (uint32);
+    function uniswapV3_addLiquidity(
+        address pool,
+        uint256 tokenId,
+        Ticks calldata ticks,
+        TokenAmounts calldata target,
+        TokenAmounts calldata min,
+        uint256 deadline
+    ) external returns (uint256 tokenId_, uint128 liquidity, TokenAmounts memory amounts);
+    function uniswapV3_removeLiquidity(
+        address pool,
+        uint256 tokenId,
+        uint128 liquidity,
+        TokenAmounts calldata min,
+        uint256 deadline
+    ) external returns (TokenAmounts memory amounts);
+}
+
+contract GroveEthereum_20260813_Test is GroveTestBase {
+
+    // UNISWAP_V3_FACET in the Sky-governed PAU Beacon.
+    address internal constant PAU_UNISWAP_V3_FACET = 0x445D9Dc752F269Be48250f1A180CAC4c61cE4bab;
+
+    bytes32 internal constant LIMIT_UNISWAP_V3_DEPOSIT  = keccak256("LIMIT_UNISWAP_V3_DEPOSIT");
+    bytes32 internal constant LIMIT_UNISWAP_V3_SWAP     = keccak256("LIMIT_UNISWAP_V3_SWAP");
+    bytes32 internal constant LIMIT_UNISWAP_V3_WITHDRAW = keccak256("LIMIT_UNISWAP_V3_WITHDRAW");
+
+    // The aggregate key is metered by the facet in 1e18-normalized units, per-asset keys in raw
+    // token units. Zero deposit slopes make the allowances cumulative for the ramp-up phase.
+    uint256 internal constant AGGREGATE_DEPOSIT_MAX   = 5_000_000e18;
+    uint256 internal constant AGGREGATE_DEPOSIT_SLOPE = 0;
+    uint256 internal constant ASSET_DEPOSIT_MAX       = 5_000_000e6;
+    uint256 internal constant ASSET_DEPOSIT_SLOPE     = 0;
+    uint256 internal constant SWAP_MAX                = 1_000_000e6;
+    uint256 internal constant SWAP_SLOPE              = 5_000_000e6 / uint256(1 days);
+
+    // Must equal the tokenId hardcoded in the 20260813 payload.
+    uint256 internal constant UNISWAP_V3_POSITION_TOKEN_ID = 1192575;
+
+    constructor() {
+        id = "20260813";
+    }
+
+    function setUp() public {
+        setupDomains("2026-07-29T10:13:44Z");
+
+        deployPayloads();
+    }
+
+    function test_ETHEREUM_enableUniswapV3Facet() public onChain(ChainIdUtils.Ethereum()) {
+        IPauControllerLike controller = IPauControllerLike(Ethereum.PAU_CONTROLLER);
+
+        bytes32 aggregateDepositKey  = makeAddressKey(LIMIT_UNISWAP_V3_DEPOSIT,  Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 aggregateWithdrawKey = makeAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.UNISWAP_V3_AUSD_USDC);
+
+        bytes32 ausdDepositKey  = makeAddressAddressKey(LIMIT_UNISWAP_V3_DEPOSIT,  Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 usdcDepositKey  = makeAddressAddressKey(LIMIT_UNISWAP_V3_DEPOSIT,  Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 ausdWithdrawKey = makeAddressAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 usdcWithdrawKey = makeAddressAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 ausdSwapKey     = makeAddressAddressKey(LIMIT_UNISWAP_V3_SWAP,     Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 usdcSwapKey     = makeAddressAddressKey(LIMIT_UNISWAP_V3_SWAP,     Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
+
+        // --- Before: facet not wired, none of the eight keys set. ---
+        assertEq(
+            controller.getDispatch(IPauControllerLike.uniswapV3_VERSION.selector).facet,
+            address(0),
+            "uniswap-v3-facet-already-wired"
+        );
+
+        _assertPauZeroRateLimit(aggregateDepositKey);
+        _assertPauZeroRateLimit(aggregateWithdrawKey);
+        _assertPauZeroRateLimit(ausdDepositKey);
+        _assertPauZeroRateLimit(usdcDepositKey);
+        _assertPauZeroRateLimit(ausdWithdrawKey);
+        _assertPauZeroRateLimit(usdcWithdrawKey);
+        _assertPauZeroRateLimit(ausdSwapKey);
+        _assertPauZeroRateLimit(usdcSwapKey);
+
+        executeAllPayloadsAndBridges();
+
+        // --- After: all 23 facet selectors dispatched to the Beacon's UniswapV3 facet. ---
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_VERSION.selector).facet,        PAU_UNISWAP_V3_FACET, "uniswap-v3-version-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_MAX_TICK_DELTA.selector).facet, PAU_UNISWAP_V3_FACET, "uniswap-v3-max-tick-delta-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_MIN_TICK.selector).facet,       PAU_UNISWAP_V3_FACET, "uniswap-v3-min-tick-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_MAX_TICK.selector).facet,       PAU_UNISWAP_V3_FACET, "uniswap-v3-max-tick-not-wired");
+
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_positionManager.selector).facet, PAU_UNISWAP_V3_FACET, "uniswap-v3-position-manager-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_router.selector).facet,          PAU_UNISWAP_V3_FACET, "uniswap-v3-router-not-wired");
+
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_setLiquidityLowerTickBound.selector).facet, PAU_UNISWAP_V3_FACET, "uniswap-v3-set-lower-tick-bound-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_setLiquidityUpperTickBound.selector).facet, PAU_UNISWAP_V3_FACET, "uniswap-v3-set-upper-tick-bound-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_setMaxSlippage.selector).facet,             PAU_UNISWAP_V3_FACET, "uniswap-v3-set-max-slippage-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_setMaxTickDelta.selector).facet,            PAU_UNISWAP_V3_FACET, "uniswap-v3-set-max-tick-delta-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_setTWAPSecondsAgo.selector).facet,          PAU_UNISWAP_V3_FACET, "uniswap-v3-set-twap-seconds-ago-not-wired");
+
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_swap.selector).facet,            PAU_UNISWAP_V3_FACET, "uniswap-v3-swap-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_addLiquidity.selector).facet,    PAU_UNISWAP_V3_FACET, "uniswap-v3-add-liquidity-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_removeLiquidity.selector).facet, PAU_UNISWAP_V3_FACET, "uniswap-v3-remove-liquidity-not-wired");
+
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getAggregateDepositRateLimitKey.selector).facet,  PAU_UNISWAP_V3_FACET, "uniswap-v3-aggregate-deposit-key-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getAggregateWithdrawRateLimitKey.selector).facet, PAU_UNISWAP_V3_FACET, "uniswap-v3-aggregate-withdraw-key-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getAssetDepositRateLimitKey.selector).facet,      PAU_UNISWAP_V3_FACET, "uniswap-v3-asset-deposit-key-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getAssetWithdrawRateLimitKey.selector).facet,     PAU_UNISWAP_V3_FACET, "uniswap-v3-asset-withdraw-key-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getSwapRateLimitKey.selector).facet,              PAU_UNISWAP_V3_FACET, "uniswap-v3-swap-key-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getLiquidityTickBounds.selector).facet,           PAU_UNISWAP_V3_FACET, "uniswap-v3-tick-bounds-getter-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getMaxSlippage.selector).facet,                   PAU_UNISWAP_V3_FACET, "uniswap-v3-max-slippage-getter-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getMaxTickDelta.selector).facet,                  PAU_UNISWAP_V3_FACET, "uniswap-v3-max-tick-delta-getter-not-wired");
+        assertEq(controller.getDispatch(IPauControllerLike.uniswapV3_getTWAPSecondsAgo.selector).facet,                PAU_UNISWAP_V3_FACET, "uniswap-v3-twap-getter-not-wired");
+
+        // The facet's own getters must agree with the keys the payload wrote.
+        assertEq(controller.uniswapV3_getAggregateDepositRateLimitKey(Ethereum.UNISWAP_V3_AUSD_USDC),  aggregateDepositKey,  "aggregate-deposit-key-mismatch");
+        assertEq(controller.uniswapV3_getAggregateWithdrawRateLimitKey(Ethereum.UNISWAP_V3_AUSD_USDC), aggregateWithdrawKey, "aggregate-withdraw-key-mismatch");
+
+        assertEq(controller.uniswapV3_getAssetDepositRateLimitKey(Ethereum.UNISWAP_V3_AUSD_USDC,  Ethereum.AUSD), ausdDepositKey,  "ausd-deposit-key-mismatch");
+        assertEq(controller.uniswapV3_getAssetDepositRateLimitKey(Ethereum.UNISWAP_V3_AUSD_USDC,  Ethereum.USDC), usdcDepositKey,  "usdc-deposit-key-mismatch");
+        assertEq(controller.uniswapV3_getAssetWithdrawRateLimitKey(Ethereum.UNISWAP_V3_AUSD_USDC, Ethereum.AUSD), ausdWithdrawKey, "ausd-withdraw-key-mismatch");
+        assertEq(controller.uniswapV3_getAssetWithdrawRateLimitKey(Ethereum.UNISWAP_V3_AUSD_USDC, Ethereum.USDC), usdcWithdrawKey, "usdc-withdraw-key-mismatch");
+
+        assertEq(controller.uniswapV3_getSwapRateLimitKey(Ethereum.UNISWAP_V3_AUSD_USDC, Ethereum.AUSD), ausdSwapKey, "ausd-swap-key-mismatch");
+        assertEq(controller.uniswapV3_getSwapRateLimitKey(Ethereum.UNISWAP_V3_AUSD_USDC, Ethereum.USDC), usdcSwapKey, "usdc-swap-key-mismatch");
+
+        _assertPauRateLimit(aggregateDepositKey, AGGREGATE_DEPOSIT_MAX, AGGREGATE_DEPOSIT_SLOPE);
+        _assertPauRateLimit(ausdDepositKey,      ASSET_DEPOSIT_MAX,     ASSET_DEPOSIT_SLOPE);
+        _assertPauRateLimit(usdcDepositKey,      ASSET_DEPOSIT_MAX,     ASSET_DEPOSIT_SLOPE);
+
+        _assertPauUnlimitedRateLimit(aggregateWithdrawKey);
+        _assertPauUnlimitedRateLimit(ausdWithdrawKey);
+        _assertPauUnlimitedRateLimit(usdcWithdrawKey);
+
+        _assertPauRateLimit(ausdSwapKey, SWAP_MAX, SWAP_SLOPE);
+        _assertPauRateLimit(usdcSwapKey, SWAP_MAX, SWAP_SLOPE);
+    }
+
+    function test_ETHEREUM_uniswapV3FacetPoolParams() public onChain(ChainIdUtils.Ethereum()) {
+        IPauControllerLike controller = IPauControllerLike(Ethereum.PAU_CONTROLLER);
+
+        executeAllPayloadsAndBridges();
+
+        // The params mirror the live ALM-side config (January 29, 2026 onboarding).
+        ( int24 lowerTickBound, int24 upperTickBound ) =
+            controller.uniswapV3_getLiquidityTickBounds(Ethereum.UNISWAP_V3_AUSD_USDC);
+
+        assertEq(controller.uniswapV3_getMaxSlippage(Ethereum.UNISWAP_V3_AUSD_USDC),    0.999e18, "max-slippage-mismatch");
+        assertEq(controller.uniswapV3_getMaxTickDelta(Ethereum.UNISWAP_V3_AUSD_USDC),   200,      "max-tick-delta-mismatch");
+        assertEq(controller.uniswapV3_getTWAPSecondsAgo(Ethereum.UNISWAP_V3_AUSD_USDC), 600,      "twap-seconds-ago-mismatch");
+
+        assertEq(lowerTickBound, -10, "lower-tick-bound-mismatch");
+        assertEq(upperTickBound, 10,  "upper-tick-bound-mismatch");
+    }
+
+    function test_ETHEREUM_uniswapV3FacetAddRemoveLiquidity() public onChain(ChainIdUtils.Ethereum()) {
+        executeAllPayloadsAndBridges();
+
+        PauContext memory ctx = _getPauContext();
+
+        uint256 depositAmount = 1_000_000e6;
+
+        deal(Ethereum.USDC, address(ctx.proxy), depositAmount);
+
+        bytes32 aggregateDepositKey = makeAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 ausdDepositKey      = makeAddressAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 usdcDepositKey      = makeAddressAddressKey(LIMIT_UNISWAP_V3_DEPOSIT, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
+
+        // A single-sided USDC range strictly below the TWAP tick keeps the facet's expected
+        // amounts price-independent, so exact min amounts can be computed here.
+        int24 tickUpper = _twapTick(Ethereum.UNISWAP_V3_AUSD_USDC, 600) - 1;
+        if (tickUpper > 10) tickUpper = 10;
+        assertGt(tickUpper, -10, "twap-tick-outside-liquidity-bounds");
+
+        bytes memory result = _callAsPauActor(ctx, abi.encodeCall(
+            IPauControllerLike.uniswapV3_addLiquidity,
+            (
+                Ethereum.UNISWAP_V3_AUSD_USDC,
+                0,
+                IPauControllerLike.Ticks({ lower: -10, upper: tickUpper }),
+                IPauControllerLike.TokenAmounts({ amount0: 0, amount1: depositAmount }),
+                IPauControllerLike.TokenAmounts({ amount0: 0, amount1: depositAmount * 999 / 1000 }),
+                block.timestamp + 1 hours
+            )
+        ));
+
+        ( uint256 tokenId, uint128 liquidity, IPauControllerLike.TokenAmounts memory deposited ) =
+            abi.decode(result, (uint256, uint128, IPauControllerLike.TokenAmounts));
+
+        assertGt(liquidity, 0, "no-liquidity-minted");
+
+        assertEq(deposited.amount0, 0,                            "ausd-unexpectedly-deposited");
+        assertGe(deposited.amount1, depositAmount * 999 / 1000,   "usdc-deposited-below-min");
+
+        assertEq(IPositionManagerLike(Ethereum.UNISWAP_V3_POSITION_MANAGER).ownerOf(tokenId), address(ctx.proxy), "position-not-owned-by-pau-proxy");
+
+        // Deposits consume the limits: the aggregate in 1e18-normalized units, per-asset raw.
+        assertEq(ctx.rateLimits.getCurrentRateLimit(aggregateDepositKey), AGGREGATE_DEPOSIT_MAX - deposited.amount1 * 1e12, "aggregate-deposit-limit-not-consumed");
+        assertEq(ctx.rateLimits.getCurrentRateLimit(usdcDepositKey),      ASSET_DEPOSIT_MAX - deposited.amount1,            "usdc-deposit-limit-not-consumed");
+        assertEq(ctx.rateLimits.getCurrentRateLimit(ausdDepositKey),      ASSET_DEPOSIT_MAX,                                "ausd-deposit-limit-consumed");
+
+        // Unwind the whole position: withdrawals are unlimited so the limit stays untouched.
+        uint256 proxyUsdcBalance = IERC20(Ethereum.USDC).balanceOf(address(ctx.proxy));
+
+        result = _callAsPauActor(ctx, abi.encodeCall(
+            IPauControllerLike.uniswapV3_removeLiquidity,
+            (
+                Ethereum.UNISWAP_V3_AUSD_USDC,
+                tokenId,
+                liquidity,
+                IPauControllerLike.TokenAmounts({ amount0: 0, amount1: deposited.amount1 * 999 / 1000 }),
+                block.timestamp + 1 hours
+            )
+        ));
+
+        IPauControllerLike.TokenAmounts memory withdrawn = abi.decode(result, (IPauControllerLike.TokenAmounts));
+
+        assertGe(withdrawn.amount1, deposited.amount1 * 999 / 1000, "usdc-not-returned");
+
+        assertEq(IERC20(Ethereum.USDC).balanceOf(address(ctx.proxy)), proxyUsdcBalance + withdrawn.amount1, "proxy-usdc-balance-mismatch");
+
+        assertEq(
+            ctx.rateLimits.getCurrentRateLimit(makeAddressKey(LIMIT_UNISWAP_V3_WITHDRAW, Ethereum.UNISWAP_V3_AUSD_USDC)),
+            type(uint256).max,
+            "aggregate-withdraw-limit-not-unlimited"
+        );
+    }
+
+    function test_ETHEREUM_uniswapV3FacetSwap() public onChain(ChainIdUtils.Ethereum()) {
+        executeAllPayloadsAndBridges();
+
+        PauContext memory ctx = _getPauContext();
+
+        uint256 amountIn = 100_000e6;
+
+        deal(Ethereum.USDC, address(ctx.proxy), amountIn);
+
+        bytes32 ausdSwapKey = makeAddressAddressKey(LIMIT_UNISWAP_V3_SWAP, Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 usdcSwapKey = makeAddressAddressKey(LIMIT_UNISWAP_V3_SWAP, Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
+
+        uint256 proxyAusdBalance = IERC20(Ethereum.AUSD).balanceOf(address(ctx.proxy));
+
+        // 0.2% tolerance covers the pool's 0.01% fee plus a near-peg price; tick delta at the
+        // configured swapMaxTickDelta.
+        bytes memory result = _callAsPauActor(ctx, abi.encodeCall(
+            IPauControllerLike.uniswapV3_swap,
+            (Ethereum.UNISWAP_V3_AUSD_USDC, Ethereum.USDC, amountIn, amountIn * 998 / 1000, 200)
+        ));
+
+        uint256 amountOut = abi.decode(result, (uint256));
+
+        assertGe(amountOut, amountIn * 998 / 1000, "swap-amount-out-below-min");
+
+        assertEq(IERC20(Ethereum.AUSD).balanceOf(address(ctx.proxy)), proxyAusdBalance + amountOut, "proxy-ausd-balance-mismatch");
+        assertEq(IERC20(Ethereum.USDC).balanceOf(address(ctx.proxy)), 0,                            "usdc-not-fully-spent");
+
+        // The swap consumes the tokenIn key by the amount spent; the AUSD key stays untouched.
+        assertEq(ctx.rateLimits.getCurrentRateLimit(usdcSwapKey), SWAP_MAX - amountIn, "usdc-swap-limit-not-consumed");
+        assertEq(ctx.rateLimits.getCurrentRateLimit(ausdSwapKey), SWAP_MAX,            "ausd-swap-limit-consumed");
+    }
+
+    function test_ETHEREUM_collectUniswapV3PositionFees() public onChain(ChainIdUtils.Ethereum()) {
+        IPositionManagerLike positionManager = IPositionManagerLike(Ethereum.UNISWAP_V3_POSITION_MANAGER);
+
+        IALMProxy almProxy = IALMProxy(Ethereum.ALM_PROXY);
+        IERC20    ausd     = IERC20(Ethereum.AUSD);
+        IERC20    usdc     = IERC20(Ethereum.USDC);
+
+        bytes32 controllerRole = almProxy.CONTROLLER();
+
+        IPositionManagerLike.Position memory position = positionManager.positions(UNISWAP_V3_POSITION_TOKEN_ID);
+
+        assertEq(position.token0, Ethereum.AUSD, "position-token0-not-ausd");
+        assertEq(position.token1, Ethereum.USDC, "position-token1-not-usdc");
+
+        // The tokenId in the payload is the ALM Proxy's one and only position NFT.
+        assertEq(positionManager.balanceOf(Ethereum.ALM_PROXY),               1,                             "alm-proxy-position-count-not-one");
+        assertEq(positionManager.tokenOfOwnerByIndex(Ethereum.ALM_PROXY, 0),  UNISWAP_V3_POSITION_TOKEN_ID,  "alm-proxy-position-token-id-mismatch");
+
+        assertEq(positionManager.ownerOf(UNISWAP_V3_POSITION_TOKEN_ID), Ethereum.ALM_PROXY, "position-not-owned-by-alm-proxy");
+
+        assertEq(almProxy.hasRole(controllerRole, Ethereum.GROVE_PROXY), false);
+
+        uint256 ausdBalance = ausd.balanceOf(Ethereum.ALM_PROXY);
+        uint256 usdcBalance = usdc.balanceOf(Ethereum.ALM_PROXY);
+
+        // The spec pins no amounts (Post-checks §2: "whatever has accrued at execution"),
+        // so the balance assertions below are bounds rather than exact values.
+        executeAllPayloadsAndBridges();
+
+        assertGe(ausd.balanceOf(Ethereum.ALM_PROXY), ausdBalance, "alm-proxy-ausd-balance-decreased");
+        assertGe(usdc.balanceOf(Ethereum.ALM_PROXY), usdcBalance, "alm-proxy-usdc-balance-decreased");
+
+        assertGt(
+            ausd.balanceOf(Ethereum.ALM_PROXY) + usdc.balanceOf(Ethereum.ALM_PROXY),
+            ausdBalance + usdcBalance,
+            "no-fees-collected"
+        );
+
+        // Only owed fees move: the position keeps its liquidity and stays with the ALM Proxy.
+        IPositionManagerLike.Position memory positionAfter = positionManager.positions(UNISWAP_V3_POSITION_TOKEN_ID);
+
+        assertEq(positionAfter.liquidity,   position.liquidity, "position-liquidity-changed");
+        assertEq(positionAfter.tokensOwed0, 0,                  "token0-fees-not-fully-collected");
+        assertEq(positionAfter.tokensOwed1, 0,                  "token1-fees-not-fully-collected");
+
+        assertEq(positionManager.ownerOf(UNISWAP_V3_POSITION_TOKEN_ID), Ethereum.ALM_PROXY, "position-owner-changed");
+
+        assertEq(almProxy.hasRole(controllerRole, Ethereum.GROVE_PROXY), false);
+    }
+
+    function test_ETHEREUM_almUniswapV3RateLimitsUnchanged() public onChain(ChainIdUtils.Ethereum()) {
+        MainnetController controller = MainnetController(_getGroveLiquidityLayerContext().controller);
+
+        bytes32 ausdDepositKey  = RateLimitHelpers.makeAssetDestinationKey(controller.LIMIT_UNISWAP_V3_DEPOSIT(),  Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 usdcDepositKey  = RateLimitHelpers.makeAssetDestinationKey(controller.LIMIT_UNISWAP_V3_DEPOSIT(),  Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 ausdWithdrawKey = RateLimitHelpers.makeAssetDestinationKey(controller.LIMIT_UNISWAP_V3_WITHDRAW(), Ethereum.AUSD, Ethereum.UNISWAP_V3_AUSD_USDC);
+        bytes32 usdcWithdrawKey = RateLimitHelpers.makeAssetDestinationKey(controller.LIMIT_UNISWAP_V3_WITHDRAW(), Ethereum.USDC, Ethereum.UNISWAP_V3_AUSD_USDC);
+
+        // --- Before: live limits from the January 29, 2026 onboarding. ---
+        _assertRateLimit(ausdDepositKey, 25_000_000e6, 25_000_000e6 / uint256(1 days));
+        _assertRateLimit(usdcDepositKey, 25_000_000e6, 25_000_000e6 / uint256(1 days));
+
+        _assertUnlimitedRateLimit(ausdWithdrawKey);
+        _assertUnlimitedRateLimit(usdcWithdrawKey);
+
+        executeAllPayloadsAndBridges();
+
+        // --- After: the ALM-side limits come out untouched (additive capacity, not a migration). ---
+        _assertRateLimit(ausdDepositKey, 25_000_000e6, 25_000_000e6 / uint256(1 days));
+        _assertRateLimit(usdcDepositKey, 25_000_000e6, 25_000_000e6 / uint256(1 days));
+
+        _assertUnlimitedRateLimit(ausdWithdrawKey);
+        _assertUnlimitedRateLimit(usdcWithdrawKey);
+    }
+
+    function test_ETHEREUM_offboardMapleSyrupUsdcDepositRateLimit() public onChain(ChainIdUtils.Ethereum()) {
+        GroveLiquidityLayerContext memory ctx = _getGroveLiquidityLayerContext();
+
+        bytes32 depositKey  = RateLimitHelpers.makeAssetKey(MainnetController(ctx.controller).LIMIT_4626_DEPOSIT(),  Ethereum.MAPLE_SYRUP_USDC);
+        bytes32 withdrawKey = RateLimitHelpers.makeAssetKey(MainnetController(ctx.controller).LIMIT_4626_WITHDRAW(), Ethereum.MAPLE_SYRUP_USDC);
+
+        // Key published in the spec (Post-checks §3), recomputed here from the live controller.
+        assertEq(depositKey, 0x99a69e57b2f387f999d6adff6eb2e707b59fdb54f06ca6211b4f20956e9bfe10, "syrup-usdc-deposit-key-mismatch");
+
+        // --- Before: deposits still capped at the onboarded 50M limit, withdrawals never set. ---
+        _assertRateLimit(depositKey, 50_000_000e6, 50_000_000e6 / uint256(1 days));
+        _assertZeroRateLimit(withdrawKey);
+
+        executeAllPayloadsAndBridges();
+
+        // --- After: the integration is inert in both directions. ---
+        _assertZeroRateLimit(depositKey);
+        _assertZeroRateLimit(withdrawKey);
+
+        vm.prank(ctx.relayer);
+        vm.expectRevert("RateLimits/zero-maxAmount");
+        MainnetController(ctx.controller).depositERC4626(Ethereum.MAPLE_SYRUP_USDC, 1e6);
+    }
+
+    function _twapTick(address pool, uint32 secondsAgo) internal view returns (int24) {
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = secondsAgo;
+        secondsAgos[1] = 0;
+
+        ( int56[] memory tickCumulatives, ) = IUniswapV3PoolLike(pool).observe(secondsAgos);
+
+        return int24((tickCumulatives[1] - tickCumulatives[0]) / int56(uint56(secondsAgo)));
+    }
+
+}


### PR DESCRIPTION
# 2026-08-13 Grove Spell

## Forum Post

[Forum Post Link](https://forum.skyeco.com/t/august-13-2026-proposed-changes-to-grove-for-upcoming-spell/28126)

## List of intended changes

### Ethereum Mainnet

**Enable the UniswapV3 facet on the Grove Diamond PAU controller**

- Wires the facet into the `ALLOCATOR-GROVE-A` DPAU controller with a single `updateIntegrations([bytes32("UNISWAP_V3_FACET")])` call; the Sky-governed PAU Beacon supplies the facet address and its 23 selector wires, so no selector data is carried in the spell
- Configures the facet's per-pool params for AUSD/USDC, without which `uniswapV3_addLiquidity` and `uniswapV3_swap` revert: `maxSlippage 0.999e18`, `maxTickDelta 200`, `twapSecondsAgo 600`, liquidity tick bounds `[-10, 10]` (mirrors the live ALM-side config from the January 29, 2026 onboarding)
- Rate limits are set on the DPAU `RateLimits` (`0xE016Ae733A77Ba77E7907aAA749394Fc5e75C0e1`), a different contract from the ALM `MainnetController` `RateLimits` acted on below, at the initial values of the facet ramp-up plan
- The deposit keys have a zero slope, so the 5M allowances are cumulative for this phase rather than daily; the aggregate key is metered by the facet in 1e18-normalized units (per-asset keys in raw token units), so the aggregate is `5_000_000e18` for a 5M token cap
- The swap keys replenish: the maximum bounds any single burst at 1M per pool token, the slope governs throughput at 5M per day
- The existing ALM-side Uniswap V3 rate limits are left unchanged: this is additive capacity on a second controller, not a migration

| rate limit | before max | before slope | after max | after slope |
| --- | --- | --- | --- | --- |
| `LIMIT_UNISWAP_V3_DEPOSIT` (AUSD/USDC pool, aggregate) | `0` | `0` | `5_000_000e18` | `0` |
| `LIMIT_UNISWAP_V3_DEPOSIT` (AUSD, AUSD/USDC pool) | `0` | `0` | `5_000_000e6` | `0` |
| `LIMIT_UNISWAP_V3_DEPOSIT` (USDC, AUSD/USDC pool) | `0` | `0` | `5_000_000e6` | `0` |
| `LIMIT_UNISWAP_V3_WITHDRAW` (AUSD/USDC pool, aggregate) | `0` | `0` | `type(uint256).max` | `0` |
| `LIMIT_UNISWAP_V3_WITHDRAW` (AUSD, AUSD/USDC pool) | `0` | `0` | `type(uint256).max` | `0` |
| `LIMIT_UNISWAP_V3_WITHDRAW` (USDC, AUSD/USDC pool) | `0` | `0` | `type(uint256).max` | `0` |
| `LIMIT_UNISWAP_V3_SWAP` (AUSD, AUSD/USDC pool) | `0` | `0` | `1_000_000e6` | `5_000_000e6 / 1 days` |
| `LIMIT_UNISWAP_V3_SWAP` (USDC, AUSD/USDC pool) | `0` | `0` | `1_000_000e6` | `5_000_000e6 / 1 days` |

**One-time `collect` on the Grove Uniswap V3 position**

- Realises the fees accrued on position NFT `tokenId 1192575` (AUSD/USDC, 0.01% fee tier) held by the Grove ALM Proxy
- `recipient` is the Grove ALM Proxy, `amount0Max` = `amount1Max` = `type(uint128).max` so all accrued fees are swept
- Atomic in-spell call (temporary `CONTROLLER` role grant + `ALMProxy.doCall` + revoke), mirroring the 20260716 syrupUSDC transfer
- Adds no new exposure and touches neither rate-limit contract

**Offboard the Maple syrupUSDC deposit rate limit**

- Grove no longer maintains a syrupUSDC position; the withdraw/redeem keys were never set, so zeroing the deposit limit makes the integration inert in both directions

| rate limit | before max | before slope | after max | after slope |
| --- | --- | --- | --- | --- |
| `LIMIT_4626_DEPOSIT` (syrupUSDC) | `50_000_000e6` | `50_000_000e6 / 1 days` | `0` | `0` |

**Out-of-spell coordination (Items 4 and 5, no payload action)**

- Item 4: the Tokenized Treasury JTRSY Instance's offchain parameters are changed via a Grove artifact update (CRR 100% -> 25%, maximum exposure 2,500,000 -> 5,000,000), per the Basin ramp-up plan
- Item 5: the `ALLOCATOR-GROVE-A` auto-line is raised (`maxLine` 5M -> 10M USDS, `gap` 1M -> 2M USDS) in the coordinated Sky Core spell on the same date
- Neither is executed by this spell and the spec defines no post-check for them here; aggregate allocator deployment stays bounded by that auto-line rather than by the Item 1 rate limits

## Spell Deployment

### Ethereum Mainnet
`0xb12C687188427d7D1E5253afA5f09A101Fbd9d4b`
[Etherscan Link](https://etherscan.io/address/0xb12C687188427d7D1E5253afA5f09A101Fbd9d4b#code)

**Codehash:**
`0x180fc2de506150de525027a135843e91123578dc1f03945b69a489dce863f85c`

## Addresses

New addresses introduced in the spell

### Ethereum Mainnet

| variable name | address | source of truth |
| --- | --- | --- |
| `PAU_UNISWAP_V3_FACET` | `0x445D9Dc752F269Be48250f1A180CAC4c61cE4bab` | `UNISWAP_V3_FACET` in `sky-ecosystem/sky-pau-registry`, Etherscan-verified as `UniswapV3Facet` (test only) |

## Dependencies Updated

_None_
