### PR TITLE
🧮 Correct number format guidance in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@
     - paramOneName - paramOneValue (`SPELL_PARAM_1_VAR_NAME`)
     - paramTwoName - paramTwoValue (`SPELL_PARAM_2_VAR_NAME`)
 
-<!-- Where applicable values expressing token amounts should mention the precision; i.e. 50_000_000e6 (use Solidity-style underscore separators, NOT dot-as-thousands-separator). -->
+<!-- Where applicable values expressing token amounts should mention the precision; i.e. 50_000_000e6 -->
 
 ## Spell Deployment
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@
     - paramOneName - paramOneValue (`SPELL_PARAM_1_VAR_NAME`)
     - paramTwoName - paramTwoValue (`SPELL_PARAM_2_VAR_NAME`)
 
-<!-- Where applicable values expressing token amounts should mention the precision; i.e. 50.000.000e6 -->
+<!-- Where applicable values expressing token amounts should mention the precision; i.e. 50_000_000e6 (use Solidity-style underscore separators, NOT dot-as-thousands-separator). -->
 
 ## Spell Deployment
 


### PR DESCRIPTION
Backports the corrected number-format guidance from `archive/20260702/20260702.md:63` to the PR template, where it was never applied.
